### PR TITLE
Add outage notice for publishing issues

### DIFF
--- a/content/issues/2026-02-17-publish.md
+++ b/content/issues/2026-02-17-publish.md
@@ -23,4 +23,4 @@ affected:
 An ongoing outage is currently preventing builds from being published. This issue
 affects both direct uploads and all builds performed on Flathub infra.
 
-We are trying to resolve it.
+We are trying to resolve it. {{< track "2026-02-17 13:56:00" >}}

--- a/content/issues/2026-02-17-publish.md
+++ b/content/issues/2026-02-17-publish.md
@@ -1,0 +1,26 @@
+---
+title: Publish outage
+date: 2026-02-17 20:09:00
+
+resolved: false
+
+# disrupted | down | notice
+severity: disrupted
+
+section: issue
+informational: false
+pin: false
+
+affected:
+#  - Build service
+  - Main repository server
+#  - Website
+#  - API
+#  - Discourse
+#  - CDN
+---
+
+An ongoing outage is currently preventing builds from being published. This issue
+affects both direct uploads and all builds performed on Flathub infra.
+
+We are trying to resolve it.

--- a/content/issues/2026-02-17-publish.md
+++ b/content/issues/2026-02-17-publish.md
@@ -9,7 +9,7 @@ severity: disrupted
 
 section: issue
 informational: false
-pin: false
+pin: true
 
 affected:
 #  - Build service

--- a/content/issues/2026-02-17-publish.md
+++ b/content/issues/2026-02-17-publish.md
@@ -1,6 +1,6 @@
 ---
 title: Publish outage
-date: 2026-02-17 20:09:00
+date: 2026-02-17 13:56:00
 
 resolved: false
 


### PR DESCRIPTION
Document ongoing outage affecting builds and services.